### PR TITLE
Use manifest name property instead of inexistent id

### DIFF
--- a/example-adapter.js
+++ b/example-adapter.js
@@ -79,7 +79,7 @@ class ExampleDevice extends Device {
 
 class ExampleAdapter extends Adapter {
   constructor(addonManager) {
-    super(addonManager, 'ExampleAdapter', manifest.id);
+    super(addonManager, 'ExampleAdapter', manifest.name);
     addonManager.addAdapter(this);
 
     if (!this.devices['example-plug']) {


### PR DESCRIPTION
The `id` property doesn't exist anymore, `name` is now pointing to the ID: https://github.com/WebThingsIO/gateway/blob/819b8cd4151ace303a6d2564fd70ef5d8cf5a0a3/src/addon-loader.js#L53